### PR TITLE
AUTH-291 AUTH-360 #qa/testing Implement custom `getUser` option

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 LabShare
+Copyright (c) 2017 LabShare
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ services.config(servicesAuth({
 services.start();
 ```
 
+## Options
+
+ * `authUrl` (`String`) - A GET endpoint that retreives a user data object with a `role` property. Optional if `getUser` is provided.
+ * `getUser` (`Function`) - A custom function for obtaining the user data. The signature is `({authToken: string, refreshToken: string}, callback: (error: Error, user) => void): void`.
+
 ## Development
 1. Install Node.js 6+
 2. Run `npm install` in the root directory of `services-auth`.

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,23 +4,25 @@ const routeEnsureAuthorized = require('./route-ensure-authorized'),
     socketEnsureAuthorized = require('./socket-ensure-authorized'),
     restrictRoute = require('./restrict-route'),
     restrictSocket = require('./restrict-socket'),
-    assert = require('assert'),
+    authUser = require('./user'),
     _ = require('lodash');
 
 /**
  * @description
- * @param {String} authUrl - The authentication endpoint used to obtain user profile information
- * @returns {function()} A LabShare Services configuration function that adds role-based authentication middleware
+ * @param {String} authUrl - The authentication endpoint used to obtain user profile information.
+ * Optional if a `getUser` function is provided.
+ * @param {Function|null} getUser - Custom function for obtaining the user data
+ * @returns {function} A LabShare Services configuration function that adds role-based authentication middleware
  * to each socket and route definition.
  */
-module.exports = function authServices({authUrl}) {
-    assert.ok(_.isString(authUrl), `services-auth: "authUrl" is required!`);
+module.exports = function authServices({authUrl = null, getUser = null}) {
+    getUser = getUser || authUser({authUrl});
 
     return ({services, sockets}) => {
         _.each(sockets, socketHandlers => {
             socketHandlers.forEach(socketHandler => {
                 if (socketHandler.accessLevel) {
-                    socketHandler.middleware.unshift(restrictSocket(authUrl), socketEnsureAuthorized);
+                    socketHandler.middleware.unshift(restrictSocket({authUrl, getUser}), socketEnsureAuthorized);
                 }
             });
         });
@@ -28,7 +30,7 @@ module.exports = function authServices({authUrl}) {
         _.each(services, routes => {
             routes.forEach(route => {
                 if (route.accessLevel) {
-                    route.middleware.unshift(restrictRoute(route, authUrl), routeEnsureAuthorized(route));
+                    route.middleware.unshift(restrictRoute({route, authUrl, getUser}), routeEnsureAuthorized(route));
                 }
             });
         });

--- a/lib/restrict-route.js
+++ b/lib/restrict-route.js
@@ -4,8 +4,7 @@
 
 'use strict';
 
-const authUser = require('./user'),
-    assert = require('assert'),
+const assert = require('assert'),
     _ = require('lodash');
 
 /**
@@ -13,12 +12,11 @@ const authUser = require('./user'),
  * the user data is stored in the request.  If there was an error
  * authenticating the user, it responds with an error status.
  * @param {Object} route - A LabShare Service route
- * @param {String} authUrl - The full URL to the user profile authentication endpoint
+ * @param {Function} getUser - Function that retrieves the user data
  * @returns {Function} authorization middleware
  */
-module.exports = function restrictRoute(route, authUrl) {
+module.exports = function restrictRoute({route, getUser}) {
     assert.ok(_.isObject(route), 'services-auth: restrict middleware requires a "route"');
-    assert.ok(_.isString(authUrl), 'services-auth: restrict middleware requires an "authUrl"');
 
     return function restrictMiddleware(req, res, next) {
         assert.ok(_.isObject(req.cookies), 'cookie-parser middleware is required!');
@@ -39,7 +37,7 @@ module.exports = function restrictRoute(route, authUrl) {
         }
 
         // Obtain user profile information using the JWT
-        authUser({authToken, refreshToken, authUrl}, (error, userData) => {
+        getUser({authToken, refreshToken}, (error, userData) => {
             if (error) {
                 // User profile had an invalid format
                 if (error.type === 'InvalidProfileError') {

--- a/lib/restrict-socket.js
+++ b/lib/restrict-socket.js
@@ -4,8 +4,7 @@
 
 'use strict';
 
-const authUser = require('./user'),
-    UnauthorizedError = require('./unauthorized-error'),
+const UnauthorizedError = require('./unauthorized-error'),
     assert = require('assert'),
     _ = require('lodash');
 
@@ -13,12 +12,10 @@ const authUser = require('./user'),
  * @description After successfully authenticating the user,
  * the user data is stored in the request.  If there was an error
  * authenticating the user, it responds with an error status.
- * @param {String} authUrl - The full URL to the user profile authentication endpoint
+ * @param {Function} getUser - Function that retrieves the user data
  * @returns {Function} authorization middleware
  */
-module.exports = function restrict(authUrl) {
-    assert.ok(_.isString(authUrl), 'services-auth: restrictSocket middleware requires an "authUrl"');
-
+module.exports = function restrict({getUser}) {
     return function restrictMiddleware({socketHandler, socket, message}, next) {
         let authToken = _.get(message, 'token') || _.get(message, 'authToken'),
             refreshToken = _.get(message, 'refreshToken');
@@ -30,7 +27,7 @@ module.exports = function restrict(authUrl) {
         }
 
         // Obtain user profile information using the JWT
-        authUser({authToken, refreshToken, authUrl}, (error, userData) => {
+        getUser({authToken, refreshToken}, (error, userData) => {
             if (error) {
                 // User profile had an invalid format
                 if (error.type === 'InvalidProfileError') {

--- a/lib/user.js
+++ b/lib/user.js
@@ -27,48 +27,58 @@ function validateProfile(profile) {
 
 /**
  * @description Authenticates a user with the LabShare API
- * @param {String} authToken - An authorization JWT token
- * @param {String} [refreshToken] - An authorization refresh token
  * @param {String} authUrl - The authentication endpoint used to obtain the user's role
  * @param {Function} callback
+ * @returns {Function}
  */
-module.exports = function authUser({authToken = '', refreshToken = '', authUrl}, callback) {
-    assert.ok(_.isFunction(callback), '`callback` must be a function');
+module.exports = function authUser({authUrl}) {
+    assert.ok(_.isString(authUrl), 'services-auth: authUser requires an "authUrl"');
 
-    if (!authToken) {
-        callback(new Error('authToken is required'));
-        return;
-    }
+    /**
+     * @param {String} authToken - An authorization JWT token
+     * @param {String} [refreshToken] - An authorization refresh token
+     */
+    return ({authToken = '', refreshToken = ''}, callback) => {
+        assert.ok(_.isFunction(callback), '`callback` must be a function');
 
-    let reqMsg = {
-        headers: {
-            'auth-token': authToken,
-            'refresh-token': refreshToken
-        }
-    };
-
-    rest.get(authUrl, reqMsg).on('complete', (data, response) => {
-        if (_.isError(data)) {
-            return callback(data);
+        if (!authToken) {
+            callback(new Error('authToken is required'));
+            return;
         }
 
-        if (response.statusCode === 200) {
-            let validation = validateProfile(data),
-                message = 'User profile is invalid: ';
-
-            if (!validation.valid) {
-                validation.errors.forEach(error => {
-                    message += `${error.property} ${error.message}. `;
-                });
-
-                let validationError = new Error(`${message}\n${JSON.stringify(data, null, 2)}`);
-                validationError.type = 'InvalidProfileError';
-
-                return callback(validationError);
+        let reqMsg = {
+            headers: {
+                'auth-token': authToken,
+                'refresh-token': refreshToken
             }
-            return callback(null, data);
-        }
+        };
 
-        callback(response.statusCode);
-    });
+        rest.get(authUrl, reqMsg).on('complete', (data, response) => {
+            if (_.isError(data)) {
+                return callback(data, null);
+            }
+
+            if (response.statusCode === 200) {
+                let validation = validateProfile(data),
+                    message = 'User profile is invalid: ';
+
+                if (!validation.valid) {
+                    validation.errors.forEach(error => {
+                        message += `${error.property} ${error.message}. `;
+                    });
+
+                    let validationError = new Error(`${message}\n${JSON.stringify(data, null, 2)}`);
+                    validationError.type = 'InvalidProfileError';
+
+                    callback(validationError);
+                    return;
+                }
+
+                 callback(null, data);
+                return;
+            }
+
+            callback(response.statusCode);
+        });
+    };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@labshare/services-auth",
-  "version": "1.17.328",
+  "version": "1.17.1010",
   "description": "LabShare Services plugin for role-based route and socket authentication",
   "main": "./",
   "scripts": {
@@ -29,7 +29,7 @@
     "revalidator": "^0.3.1"
   },
   "devDependencies": {
-    "@labshare/services": "git+https://github.com/Labshare/services.git",
+    "@labshare/services": "*",
     "cookie-parser": "^1.4.3",
     "express": "^4.14.0",
     "istanbul": "^0.4.5",
@@ -37,7 +37,7 @@
     "nock": "^8.2.1",
     "portfinder": "^1.0.12",
     "proxyquire": "^1.7.10",
-    "socket.io-client": "^1.7.2",
-    "supertest": "^2.0.1"
+    "socket.io-client": "^2.0.3",
+    "supertest": "^3.0.0"
   }
 }

--- a/test/unit/lib/index_spec.js
+++ b/test/unit/lib/index_spec.js
@@ -5,6 +5,7 @@ const express = require('express'),
     clientio = require('socket.io-client'),
     supertest = require('supertest'),
     {Services} = require('@labshare/services'),
+    servicesAuth = require('../../../lib/index'),
     http = require('http');
 
 function getRole(authToken) {
@@ -32,8 +33,7 @@ function getProfile(authToken) {
 
 describe('Services-Auth', () => {
 
-    let servicesAuth,
-        authServerUrl,
+    let authServerUrl,
         authServer,
         packagesPath,
         apiPackage1Prefix,
@@ -65,7 +65,6 @@ describe('Services-Auth', () => {
     });
 
     afterEach(done => {
-        delete global.LabShare;
         authServer.close(done);
     });
 
@@ -90,39 +89,20 @@ describe('Services-Auth', () => {
                 port = unusedPort;
                 socketAPIUrl = `http://localhost:${unusedPort}${apiPackage1Prefix}`;
 
-                // TODO: temporary until options for Services are fixed
-                global.LabShare = {
-                    Config: {
-                        services: {
-                            Listen: {
-                                Port: unusedPort
-                            }
-                        }
-                    }
-                };
-
                 services = new Services({
+                    listen: {
+                        port: unusedPort
+                    },
                     logger: loggerMock,
                     main: packagesPath,
                     morgan: {
                         enable: false
                     },
-                    socket:{
+                    socket: {
                         connections: []
                     }
 
                 });
-
-                servicesAuth = require('../../../lib/index');
-
-                services.config(servicesAuth({
-                    authUrl: authServerUrl
-                }));
-
-                servicesServer = services.start();
-
-                request = supertest(servicesServer);
-                clientSocket = clientio.connect(socketAPIUrl);
 
                 done();
             });
@@ -133,87 +113,164 @@ describe('Services-Auth', () => {
             servicesServer.close(done);
         });
 
-        it('allows users with the appropriate role', done => {
-            request.get('/api-package-1-namespace/staff/task')
-                .set('auth-token', 'staff-token')
-                .expect('staff task complete')
-                .then(() => {
+        describe('with default getUser function', () => {
+
+            beforeEach(() => {
+                services.config(servicesAuth({
+                    authUrl: authServerUrl
+                }));
+
+                servicesServer = services.start();
+
+                request = supertest(servicesServer);
+                clientSocket = clientio.connect(socketAPIUrl);
+            });
+
+            it('allows users with the appropriate role', done => {
+                request.get('/api-package-1-namespace/staff/task')
+                    .set('auth-token', 'staff-token')
+                    .expect('staff task complete')
+                    .then(() => {
+                        done();
+                    })
+                    .catch(done.fail);
+            });
+
+            it('blocks users without sufficient privileges', done => {
+                request.get('/api-package-1-namespace/admin/task')
+                    .set('auth-token', 'user-token')
+                    .expect(403)
+                    .then(() => {
+                        done();
+                    })
+                    .catch(done.fail);
+            });
+
+            it('checks if the user is authorized with socket messages', done => {
+                clientSocket.emit('staff.task', {token: 'staff-token'}, (error, result) => {
+                    if (error) {
+                        done.fail(error);
+                        return;
+                    }
+                    expect(result).toBe('staff task complete');
                     done();
-                })
-                .catch(done.fail);
-        });
-
-        it('blocks users without sufficient privileges', done => {
-            request.get('/api-package-1-namespace/admin/task')
-                .set('auth-token', 'user-token')
-                .expect(403)
-                .then(() => {
-                    done();
-                })
-                .catch(done.fail);
-        });
-
-        it('checks if the user is authorized with socket messages', done => {
-            clientSocket.emit('staff.task', {token: 'staff-token'}, (error, result) => {
-                expect(error).toBeNull();
-                expect(result).toBe('staff task complete');
-                done();
-            });
-        });
-
-        it('fails to authorize user if they do not have the appropriate role', done => {
-            clientSocket.emit('admin.task', {token: 'user-token'}, (error, message) => {
-                expect(message).toBeUndefined();
-                expect(error.message).toBe('Forbidden');
-                expect(error.data.code).toBe(403);
-                done();
-            });
-        });
-
-        it('allows complex interactions such as role-based channel notifications', done => {
-            let clientA = clientio.connect(socketAPIUrl),
-                clientB = clientio.connect(socketAPIUrl),
-                clientC = clientio.connect(socketAPIUrl),
-                clientD = clientio.connect(socketAPIUrl);
-
-            // Can't subscribe to notifications without the correct role
-            clientB.emit('subscribe:notifications', {token: 'user-token'}, error => {
-                expect(error.data.code).toBe(403);
-
-                clientB.disconnect();
-            });
-
-            clientD.emit('subscribe:notifications', {token: 'admin-token'}, (error, message) => {
-                expect(message).toContain('Archived admin notification 1');
-            });
-
-            clientD.on('staff:notification', () => {
-                jasmine.fail('Admin user should not be in the staff channel!');
-            });
-
-            clientA.emit('subscribe:notifications', {token: 'staff-token'}, (error, message) => {
-                expect(message).toContain('Archived notification 1');
-            });
-
-            clientA.on('staff:notification', message => {
-                expect(message).toContain('Something was processed by smithj');
-
-                clientA.disconnect();
-                clientC.disconnect();
-                clientD.disconnect();
-
-                done();
-            });
-
-            clientC.emit('subscribe:notifications', {token: 'staff-token'}, (error, message) => {
-                expect(message).toContain('Archived notification 1');
-
-                // The resulting notification should be sent to everyone subscribed to the staff channel
-                clientC.emit('process:something', (error, message) => {
-                    expect(error).toBeNull();
-                    expect(message).toContain('processing finished');
                 });
             });
+
+            it('fails to authorize user if they do not have the appropriate role', done => {
+                clientSocket.emit('admin.task', {token: 'user-token'}, (error, message) => {
+                    expect(message).toBeUndefined();
+                    expect(error.message).toBe('Forbidden');
+                    expect(error.data.code).toBe(403);
+                    done();
+                });
+            });
+
+            it('allows complex interactions such as role-based channel notifications', done => {
+                let clientA = clientio.connect(socketAPIUrl),
+                    clientB = clientio.connect(socketAPIUrl),
+                    clientC = clientio.connect(socketAPIUrl),
+                    clientD = clientio.connect(socketAPIUrl);
+
+                // Can't subscribe to notifications without the correct role
+                clientB.emit('subscribe:notifications', {token: 'user-token'}, error => {
+                    expect(error.data.code).toBe(403);
+
+                    clientB.disconnect();
+                });
+
+                clientD.emit('subscribe:notifications', {token: 'admin-token'}, (error, message) => {
+                    expect(message).toContain('Archived admin notification 1');
+                });
+
+                clientD.on('staff:notification', () => {
+                    jasmine.fail('Admin user should not be in the staff channel!');
+                });
+
+                clientA.emit('subscribe:notifications', {token: 'staff-token'}, (error, message) => {
+                    expect(message).toContain('Archived notification 1');
+                });
+
+                clientA.on('staff:notification', message => {
+                    expect(message).toContain('Something was processed by smithj');
+
+                    clientA.disconnect();
+                    clientC.disconnect();
+                    clientD.disconnect();
+
+                    done();
+                });
+
+                clientC.emit('subscribe:notifications', {token: 'staff-token'}, (error, message) => {
+                    expect(message).toContain('Archived notification 1');
+
+                    // The resulting notification should be sent to everyone subscribed to the staff channel
+                    clientC.emit('process:something', (error, message) => {
+                        expect(error).toBeNull();
+                        expect(message).toContain('processing finished');
+                    });
+                });
+            });
+
+        });
+
+        describe('with a custom getUser function', () => {
+
+            beforeEach(() => {
+                services.config(servicesAuth({
+                    getUser: ({}, callback) => {
+                        callback(null, {
+                            role: 'staff'
+                        });
+                    }
+                }));
+
+                servicesServer = services.start();
+
+                request = supertest(servicesServer);
+                clientSocket = clientio.connect(socketAPIUrl);
+            });
+
+            it('allows users with the appropriate role', done => {
+                request.get('/api-package-1-namespace/staff/task')
+                    .set('auth-token', 'staff-token')
+                    .expect('staff task complete')
+                    .then(() => {
+                        done();
+                    })
+                    .catch(done.fail);
+            });
+
+            it('blocks users without sufficient privileges', done => {
+                request.get('/api-package-1-namespace/admin/task')
+                    .set('auth-token', 'user-token')
+                    .expect(403)
+                    .then(() => {
+                        done();
+                    })
+                    .catch(done.fail);
+            });
+
+            it('checks if the user is authorized with socket messages', done => {
+                clientSocket.emit('staff.task', {token: 'staff-token'}, (error, result) => {
+                    if (error) {
+                        done.fail(error);
+                        return;
+                    }
+                    expect(result).toBe('staff task complete');
+                    done();
+                });
+            });
+
+            it('fails to authorize user if they do not have the appropriate role', done => {
+                clientSocket.emit('admin.task', {token: 'user-token'}, (error, message) => {
+                    expect(message).toBeUndefined();
+                    expect(error.message).toBe('Forbidden');
+                    expect(error.data.code).toBe(403);
+                    done();
+                });
+            });
+
         });
 
     });

--- a/test/unit/lib/user_spec.js
+++ b/test/unit/lib/user_spec.js
@@ -24,12 +24,12 @@ describe('Auth User', () => {
 
     it('throws with invalid arguments', () => {
         expect(() => {
-            authUser(token, null);
+            authUser({authUrl: null});
         }).toThrow();
     });
 
     it('fails if the token is missing or empty', done => {
-        authUser({authToken: '', authUrl}, error => {
+        authUser({authUrl})({authToken: ''}, error => {
             expect(error.message).toMatch(/authToken is required/i);
             done();
         });
@@ -47,7 +47,7 @@ describe('Auth User', () => {
             return userData;
         });
 
-        authUser({authToken: token, refreshToken, authUrl}, (error, data) => {
+        authUser({authUrl})({authToken: token, refreshToken}, (error, data) => {
             expect(error).toBeNull();
             expect(data).toEqual(userData);
             done();
@@ -62,7 +62,7 @@ describe('Auth User', () => {
 
         request.reply(200, userData);
 
-        authUser({authToken: token, authUrl}, (error, data) => {
+        authUser({authUrl})({authToken: token}, (error, data) => {
             expect(error.message).toContain('invalid');
             expect(data).toBeUndefined();
             done();
@@ -72,7 +72,7 @@ describe('Auth User', () => {
     it('fails if the response status is not 200', done => {
         request.reply(500, {});
 
-        authUser({authToken: token, authUrl}, (error, data) => {
+        authUser({authUrl})({authToken: token}, (error, data) => {
             expect(error).toBe(500);
             expect(data).toBeUndefined();
             done();


### PR DESCRIPTION
 - The `getUser` option is a function that returns the user data containing
the user's role. It replaces the `authUrl` GET request when present.
 - Update dependencies
 - Update docs
 - Bump version
 - Update tests