### PR TITLE
AUTH-1006 AUTH-1019 #qa/testing Use RS256 to validate all JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ npm i @labshare/services-auth --save
 
 ## Options
 
- * `authUrl` (`String`) - The base URL for a remote LabShare Auth service. Example: `https://a.labshare.org/_api`
- * `organization` (`String`) - The LabShare Auth organization ID the API service is registered to.
- * `audience` (`String`) - The API service's identifier registered to the LabShare Auth service. This is used for JWT `audience` validation.
- * `getUser` (`Function`) - An optional, custom function for obtaining the user data. The signature is `({authToken: string, refreshToken: string}, callback: (error: Error, user) => void): void`.
+ * `authUrl` (`String`) - The base URL for a remote LabShare Auth service. Example: `https://a.labshare.org/_api`. Required.
+ * `organization` (`String`) - The LabShare Auth organization ID the API service is registered to. Required if `secretProvider` is not specified.
+ * `audience` (`String`) - An optional API service identifier registered to the LabShare Auth service. This is used for JWT `audience` validation.
  * `issuer` (`String`) - Optional value for validating the JWT issuer (the `iss` claim).
  * `secretProvider` (`Function`) - An optional, custom function for obtaining the signing certificate for RS256. The signature is `(req, header: {alg: string}, payload, cb: (error: Error, signingCert: string) => void): void`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,14 @@ function httpRS256({secret, audience, issuer}) {
             secret,
             audience,   // Optionally validate the audience and the issuer as well
             issuer
-        })(req, res, next);
+        })(req, res, (error) => {
+            if (error) {
+                res.status(401).send(error.message);
+                return;
+            }
+
+            next();
+        });
     }
 }
 
@@ -85,21 +92,14 @@ module.exports = function authorize({authUrl, organization, secretProvider = nul
     return ({services, sockets}) => {
         each(sockets, socketHandlers => {
             socketHandlers.forEach(socketHandler => {
-                let middleware = [];
-
                 // Validate JWT using RS256
-                if (socketHandler.scope || socketHandler.accessLevel) {
-                    middleware.push(
+                if (socketHandler.scope) {
+                    socketHandler.middleware.unshift(
                         socketRS256({
                             audience,
                             issuer,
                             jwksClientOptions
-                        })
-                    );
-                }
-
-                if (socketHandler.scope) {
-                    middleware.push(
+                        }),
                         jwtAuthzSocket(socketHandler.scope)
                     );
                 }
@@ -108,34 +108,24 @@ module.exports = function authorize({authUrl, organization, secretProvider = nul
                 if (socketHandler.accessLevel) {
                     deprecate(DEPRECATION_NOTICE);
 
-                    middleware.push(
+                    socketHandler.middleware.unshift(
                         restrictSocket({authUrl, getUser}),
                         socketEnsureAuthorized
                     );
                 }
-
-                socketHandler.middleware.unshift(...middleware);
             });
         });
 
         each(services, routes => {
             routes.forEach(route => {
-                let middleware = [];
-
-                // Validate JWT using RS256
-                if (route.scope || route.accessLevel) {
-                    middleware.push(
+                // Validate JWT using RS256 and check Resource Scopes
+                if (route.scope) {
+                    route.middleware.unshift(
                         httpRS256({
                             secret: secretProvider || defaultSecretProvider,
                             audience,
                             issuer
-                        })
-                    );
-                }
-
-                // If scope, check scope
-                if (route.scope) {
-                    middleware.push(
+                        }),
                         authorizeJWT(route.scope)
                     );
                 }
@@ -144,13 +134,11 @@ module.exports = function authorize({authUrl, organization, secretProvider = nul
                 if (route.accessLevel) {
                     deprecate(DEPRECATION_NOTICE);
 
-                    middleware.push(
+                    route.middleware.unshift(
                         restrictRoute({route, authUrl, getUser}),
                         routeEnsureAuthorized(route)
                     );
                 }
-
-                route.middleware.unshift(...middleware);
             });
         });
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,13 @@ const routeEnsureAuthorized = require('./route-ensure-authorized'),
     restrictSocket = require('./restrict-socket'),
     authUser = require('./user'),
     deprecate = require('deprecate'),
-    _ = require('lodash'),
+    {each} = require('lodash'),
     jwt = require('express-jwt'),
     jwtAuthz = require('express-jwt-authz'),
-    jwksClient = require('jwks-rsa');
+    socketRS256 = require('./socket/rs256'),
+    jwksClient = require('jwks-rsa'),
+    getBearerToken = require('./utils/get-bearer-token'),
+    jwtAuthzSocket = require('./jwt-authz-socket');
 
 /**
  * @description Wrapper for express-jwt-authz middleware that passes over CORS OPTIONS requests
@@ -31,38 +34,73 @@ function authorizeJWT(expectedScope) {
 const DEPRECATION_NOTICE = `LabShare API "accessLevel" authorization is deprecated. Please check https://github.com/LabShare/services-auth#usage for more info.`;
 
 /**
+ * @description Validate Authorization Bearer Token using RS256 if it exists as a request header.
+ * @param secret
+ * @param audience
+ * @param issuer
+ * @returns {function(*=, *=, *=)}
+ * @private
+ */
+function httpRS256({secret, audience, issuer}) {
+    return function rs256(req, res, next) {
+        jwt({
+            getToken: getBearerToken,
+            secret,
+            audience,   // Optionally validate the audience and the issuer as well
+            issuer
+        })(req, res, next);
+    }
+}
+
+/**
  * @description Enables Resource Scope authorization on LabShare Service API routes and sockets using RS256 for JWT validation.
- * @param {String} [authUrl] - The base URL for the LabShare Auth service. Optional if `getUser` is provided for legacy HS256 JWT validation strategy.
- * @param {String} [organization] - A LabShare Auth organization
+ * @param {String} authUrl - The base URL for the LabShare Auth service.
+ * @param {String} organization - A LabShare Auth organization. Optional if `secretProvider` is specified.
  * @param {String} [audience] - A unique identifier for the API service registered as a Resource Server in LabShare Auth
  * @param {String} [issuer] - Validate JWT issuer claim against the expected value
- * @param {Function|null} getUser - Custom function for obtaining the user data
  * @param {Function|null} secretProvider - Custom function for obtaining the RS256 signing certificate. Function signature: (req, header, payload, cb).
  * @returns {function()} A LabShare Services configuration function that adds scope-based authentication middleware
  * to each socket and route definition.
+ * @public
  */
-module.exports = function authorize({authUrl = null, getUser = null, secretProvider = null, organization, audience, issuer}) {
-    getUser = getUser || authUser({authUrl});
+module.exports = function authorize({authUrl, organization, secretProvider = null, audience = null, issuer = null}) {
+    if (!authUrl) {
+        throw new Error('`authUrl` is required');
+    }
 
-    const client = jwksClient.expressJwtSecret({
-        cache: true,
-        rateLimit: true,   // See: https://github.com/auth0/node-jwks-rsa#rate-limiting
-        jwksRequestsPerMinute: 10,
-        jwksUri: `${authUrl}/auth/${organization}/.well-known/jwks.json`
-    });
+    if (!organization && !secretProvider) {
+        throw new Error('`organization` is required');
+    }
+
+    const getUser = authUser({authUrl}),
+        jwksClientOptions = {
+            cache: true,
+            rateLimit: true,   // See: https://github.com/auth0/node-jwks-rsa#rate-limiting
+            jwksRequestsPerMinute: 10,
+            jwksUri: `${authUrl}/auth/${organization}/.well-known/jwks.json`
+        },
+        defaultSecretProvider = jwksClient.expressJwtSecret(jwksClientOptions);
 
     // Attach authorization middleware to each non-public Socket.io event handler and Express HTTP route definition
     return ({services, sockets}) => {
-        _.each(sockets, socketHandlers => {
+        each(sockets, socketHandlers => {
             socketHandlers.forEach(socketHandler => {
+                let middleware = [];
+
+                // Validate JWT using RS256
+                if (socketHandler.scope || socketHandler.accessLevel) {
+                    middleware.push(
+                        socketRS256({
+                            audience,
+                            issuer,
+                            jwksClientOptions
+                        })
+                    );
+                }
+
                 if (socketHandler.scope) {
-                    socketHandler.middleware.unshift(
-                        jwt({
-                            secret: secretProvider || client,
-                            audience,   // Optionally validate the audience and the issuer as well
-                            issuer
-                        }),
-                        jwtAuthz(socketHandler.scope)
+                    middleware.push(
+                        jwtAuthzSocket(socketHandler.scope)
                     );
                 }
 
@@ -70,23 +108,34 @@ module.exports = function authorize({authUrl = null, getUser = null, secretProvi
                 if (socketHandler.accessLevel) {
                     deprecate(DEPRECATION_NOTICE);
 
-                    socketHandler.middleware.unshift(
+                    middleware.push(
                         restrictSocket({authUrl, getUser}),
                         socketEnsureAuthorized
                     );
                 }
+
+                socketHandler.middleware.unshift(...middleware);
             });
         });
 
-        _.each(services, routes => {
+        each(services, routes => {
             routes.forEach(route => {
-                if (route.scope) {
-                    route.middleware.unshift(
-                        jwt({
-                            secret: secretProvider || client,
+                let middleware = [];
+
+                // Validate JWT using RS256
+                if (route.scope || route.accessLevel) {
+                    middleware.push(
+                        httpRS256({
+                            secret: secretProvider || defaultSecretProvider,
                             audience,
                             issuer
-                        }),
+                        })
+                    );
+                }
+
+                // If scope, check scope
+                if (route.scope) {
+                    middleware.push(
                         authorizeJWT(route.scope)
                     );
                 }
@@ -95,11 +144,13 @@ module.exports = function authorize({authUrl = null, getUser = null, secretProvi
                 if (route.accessLevel) {
                     deprecate(DEPRECATION_NOTICE);
 
-                    route.middleware.unshift(
+                    middleware.push(
                         restrictRoute({route, authUrl, getUser}),
                         routeEnsureAuthorized(route)
                     );
                 }
+
+                route.middleware.unshift(...middleware);
             });
         });
     }

--- a/lib/jwt-authz-socket.js
+++ b/lib/jwt-authz-socket.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const UnauthorizedError = require('./unauthorized-error');
+
+/**
+ * @description Validate Resource Scopes assigned to Socket API.
+ * Based on https://www.npmjs.com/package/express-jwt-authz
+ * @param expectedScopes
+ * @returns {function({socket: *, message: *}, *=)}
+ * @private
+ */
+module.exports = function jwtAuthzSocket(expectedScopes = []) {
+    function error(next) {
+        next(new UnauthorizedError(401, 'Unauthorized'), null);
+    }
+
+    return ({socket, message}, next) => {
+        if (expectedScopes.length === 0) {
+            next(null, null);
+            return;
+        }
+
+        if (!socket.user || typeof socket.user.scope !== 'string') {
+            error(next);
+            return;
+        }
+
+        const scopes = socket.user.scope.split(' '),
+            allowed = expectedScopes.some((scope) => scopes.indexOf(scope) !== -1);
+
+        return allowed ? next(null, null) : error(next)
+    };
+}

--- a/lib/restrict-route.js
+++ b/lib/restrict-route.js
@@ -5,7 +5,8 @@
 'use strict';
 
 const assert = require('assert'),
-    _ = require('lodash');
+    getBearerToken = require('./utils/get-bearer-token'),
+    {isObject} = require('lodash');
 
 /**
  * @description After successfully authenticating the user,
@@ -16,33 +17,16 @@ const assert = require('assert'),
  * @returns {Function} authorization middleware
  */
 module.exports = function restrictRoute({route, getUser}) {
-    assert.ok(_.isObject(route), 'services-auth: restrict middleware requires a "route"');
+    assert.ok(isObject(route), 'services-auth: restrict middleware requires a "route"');
 
-    return function restrictMiddleware(req, res, next) {
-        assert.ok(_.isObject(req.cookies), 'cookie-parser middleware is required!');
+    return (req, res, next) => {
+        assert.ok(isObject(req.cookies), 'cookie-parser middleware is required!');
 
-        let authToken = '';
-
-        // Backwards compatibility for "Authorization: Bearer [Token]" header format
-        if (req.headers.authorization) {
-            const parts = req.headers.authorization.split(' ');
-
-            if (parts.length === 2) {
-                const scheme = parts[0],
-                    credentials = parts[1];
-
-                if (/^Bearer$/i.test(scheme)) {
-                    authToken = credentials;
-                }
-            }
-        }
-
-        authToken = authToken || req.headers['auth-token'] || req.cookies.authToken || '';
-
-        const refreshToken = req.headers['refresh-token'] || req.cookies.refreshToken || '';
+        const authToken = getBearerToken(req),
+            refreshToken = req.headers['refresh-token'] || req.cookies.refreshToken || '';
 
         // Don't process unauthenticated or already authenticated requests
-        if (!authToken || req.user || !route.accessLevel || route.accessLevel === 'public') {
+        if (!authToken || !route.accessLevel || route.accessLevel === 'public') {
             next();
             return;
         }

--- a/lib/restrict-socket.js
+++ b/lib/restrict-socket.js
@@ -5,7 +5,7 @@
 'use strict';
 
 const UnauthorizedError = require('./unauthorized-error'),
-    _ = require('lodash');
+    {get} = require('lodash');
 
 /**
  * @description After successfully authenticating the user,
@@ -15,9 +15,9 @@ const UnauthorizedError = require('./unauthorized-error'),
  * @returns {Function} authorization middleware
  */
 module.exports = function restrict({getUser}) {
-    return function restrictMiddleware({socketHandler, socket, message}, next) {
-        let authToken = _.get(message, 'token') || _.get(message, 'authToken'),
-            refreshToken = _.get(message, 'refreshToken');
+    return ({socketHandler, socket, message}, next) => {
+        const authToken = get(message, 'token') || get(message, 'authToken'),
+            refreshToken = get(message, 'refreshToken');
 
         // Don't process unauthenticated socket messages
         if (!authToken || !socketHandler.accessLevel || socketHandler.accessLevel === 'public') {

--- a/lib/socket/rs256.js
+++ b/lib/socket/rs256.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const {verify, decode} = require('jsonwebtoken'),
+    {get} = require('lodash'),
+    jwksClient = require('jwks-rsa'),
+    UnauthorizedError = require('../unauthorized-error');
+
+/**
+ * @description Validates Authorization Bearer Token using RS256 if it exists on the Socket message.
+ * @param audience
+ * @param issuer
+ * @param jwksClientOptions
+ * @returns {function(*=, *=, *=)}
+ * @private
+ */
+module.exports = function socketRS256({audience, issuer, jwksClientOptions}) {
+    return ({socket, message}, next) => {
+        const token = get(message, 'token') || get(message, 'authToken');
+
+        if (!token) {
+            next(null, null);
+            return;
+        }
+
+        const decodedToken = decode(token, {complete: true}) || {},
+            client = jwksClient(jwksClientOptions),
+            {header} = decodedToken;
+
+        // Only RS256 is supported.
+        if (!header || header.alg !== 'RS256') {
+            next(new UnauthorizedError(401, 'Unauthorized'), null);
+            return;
+        }
+
+        client.getSigningKey(header.kid, (err, key) => {
+            if (err) {
+                socket.emit('unauthorized');
+                next(new UnauthorizedError(401, 'Unauthorized'), null);
+                return;
+            }
+
+            // Verify the JWT using the public certificate from the JWKS
+            verify(token, key.publicKey || key.rsaPublicKey, {
+                audience,
+                issuer
+            }, (error, decoded) => {
+                if (error) {
+                    socket.emit('unauthorized');
+                    next(new UnauthorizedError(401, 'Unauthorized'), null);
+                    return;
+                }
+
+                // Store the decoded Bearer Token on the socket
+                socket.user = decoded;
+
+                next(null, null);
+            });
+        });
+    }
+}

--- a/lib/socket/rs256.js
+++ b/lib/socket/rs256.js
@@ -50,11 +50,11 @@ module.exports = function socketRS256({audience, issuer, jwksClientOptions}) {
                     return;
                 }
 
-                // Store the decoded Bearer Token on the socket
+                // Store the decoded Bearer Token claims on the socket
                 socket.user = decoded;
 
                 next(null, null);
             });
         });
     }
-}
+};

--- a/lib/user.js
+++ b/lib/user.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const request = require('request-promise'),
-    _ = require('lodash'),
+    {isString, isFunction} = require('lodash'),
     assert = require('assert'),
     revalidator = require('revalidator');
 
 function validateProfile(profile) {
-    let constraints = {
+    const constraints = {
         properties: {
             email: {
                 description: 'The user\'s email address',
@@ -28,28 +28,28 @@ function validateProfile(profile) {
 /**
  * @description Authenticates a user with the LabShare API
  * @param {String} authUrl - The remote LabShare Auth service's base url
- * @param {Function} callback
  * @returns {Function}
  */
 module.exports = function authUser({authUrl}) {
-    assert.ok(_.isString(authUrl), 'services-auth: authUser requires an "authUrl"');
+    assert.ok(isString(authUrl), 'services-auth: authUser requires an "authUrl"');
 
     /**
      * @param {String} authToken - An authorization JWT token
      * @param {String} [refreshToken] - An authorization refresh token
+     * @param {Function} callback
      */
     return ({authToken = '', refreshToken = ''}, callback) => {
-        assert.ok(_.isFunction(callback), '`callback` must be a function');
+        assert.ok(isFunction(callback), '`callback` must be a function');
 
         if (!authToken) {
             callback(new Error('authToken is required'));
             return;
         }
 
-        const profileUrl = authUrl + '/auth/me';
+        const userProfileUrl = `${authUrl}/auth/me`;
 
         request.get({
-            url: profileUrl,
+            url: userProfileUrl,
             json: true,
             headers: {
                 'auth-token': authToken,

--- a/lib/utils/get-bearer-token.js
+++ b/lib/utils/get-bearer-token.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * @description Parses Authorization Bearer token from the request headers
+ * @param req
+ * @returns {string|*}
+ */
+module.exports = function getAuthorizationBearerToken(req) {
+    let authToken = '';
+
+    // Backwards compatibility for "Authorization: Bearer [Token]" header format
+    if (req.headers.authorization) {
+        const parts = req.headers.authorization.split(' ');
+
+        if (parts.length === 2) {
+            const scheme = parts[0],
+                credentials = parts[1];
+
+            if (/^Bearer$/i.test(scheme)) {
+                authToken = credentials;
+            }
+        }
+    }
+
+    return authToken || req.headers['auth-token'] || req.cookies.authToken || '';
+};

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "istanbul": "^0.4.5",
     "jasmine": "^2.5.2",
     "nock": "^8.2.1",
+    "pem-jwk": "^1.5.1",
     "portfinder": "^1.0.12",
+    "selfsigned": "^1.10.2",
     "socket.io-client": "^2.0.3",
     "supertest": "^3.0.0"
   }

--- a/test/fixtures/main-package/node_modules/api-package1/api/api1Service.js
+++ b/test/fixtures/main-package/node_modules/api-package1/api/api1Service.js
@@ -2,26 +2,50 @@ function api1Service() {
 
     function userTask(req, res) {
         res.send('user task complete');
-    };
+    }
 
     function staffTask(req, res) {
         res.send('staff task complete');
-    };
+    }
 
     function publicTask(req, res) {
         res.send('public task complete');
-    };
+    }
 
     function adminTask(req, res) {
         res.send('admin task complete');
-    };
+    }
+
+    function getBooks(req, res) {
+        res.send('got books');
+    }
+    
+    function writeBook(req, res) {
+        res.send('wrote book');
+    }
 
     return {
         routes: [
             {path: '/user/task', httpMethod: 'GET', middleware: userTask, accessLevel: 'user'},
             {path: '/public/task', httpMethod: 'GET', middleware: publicTask},
             {path: '/staff/task', httpMethod: 'GET', middleware: staffTask, accessLevel: 'staff'},
-            {path: '/admin/task', httpMethod: 'GET', middleware: adminTask, accessLevel: 'admin'}
+            {path: '/admin/task', httpMethod: 'GET', middleware: adminTask, accessLevel: 'admin'},
+            {
+                path: '/books',
+                httpMethod: 'GET',
+                middleware: getBooks,
+                scope: [
+                    'read:books'
+                ]
+            },
+            {
+                path: '/books',
+                httpMethod: 'POST',
+                middleware: writeBook,
+                scope: [
+                    'write:books'
+                ]
+            }
         ]
     };
 }

--- a/test/fixtures/main-package/node_modules/socket-api-package1/api/socket-connection.js
+++ b/test/fixtures/main-package/node_modules/socket-api-package1/api/socket-connection.js
@@ -27,5 +27,25 @@ exports.sockets = [
         onEvent: ({}, callback) => {
             callback(null, 'public task complete');
         }
+    },
+    {
+        event: 'read.books',
+        httpMethod: 'GET',
+        onEvent: ({}, callback) => {
+            callback(null, 'got books');
+        },
+        scope: [
+            'read:books'
+        ]
+    },
+    {
+        event: 'write.books',
+        httpMethod: 'POST',
+        onEvent: ({}, callback) => {
+            callback(null, 'wrote book');
+        },
+        scope: [
+            'write:books'
+        ]
     }
 ]

--- a/test/unit/lib/index_spec.js
+++ b/test/unit/lib/index_spec.js
@@ -193,6 +193,16 @@ describe('Services-Auth', () => {
                     .catch(done.fail);
             });
 
+            it('requires an Authorization Bearer token in the request headers', (done) => {
+                request.post('/api-package-1-namespace/books')
+                    .expect(401)
+                    .then((res) => {
+                        expect(res.text).toBe('No authorization token was found');
+                        done();
+                    })
+                    .catch(done.fail);
+            });
+
             it('checks if the user is authorized with socket messages', done => {
                 const token = createToken(1, 'read:books');
 

--- a/test/unit/lib/index_spec.js
+++ b/test/unit/lib/index_spec.js
@@ -5,16 +5,19 @@ const express = require('express'),
     clientio = require('socket.io-client'),
     supertest = require('supertest'),
     {Services} = require('@labshare/services'),
+    {pem2jwk} = require('pem-jwk'),
     servicesAuth = require('../../../lib/index'),
-    http = require('http');
+    jws = require('jsonwebtoken'),
+    http = require('http'),
+    selfsigned = require('selfsigned');
 
 function getRole(authToken) {
-    switch (authToken) {
-        case 'user-token':
+    switch (jws.decode(authToken).sub) {
+        case 1:
             return 'user';
-        case 'staff-token':
+        case 2:
             return 'staff';
-        case 'admin-token':
+        case 3:
             return 'admin';
         default:
             return {};
@@ -34,20 +37,59 @@ function getProfile(authToken) {
 describe('Services-Auth', () => {
 
     const packagesPath = './test/fixtures/main-package',
-        apiPackage1Prefix = '/socket-api-package-1-namespace';
+        apiPackage1Prefix = '/socket-api-package-1-namespace',
+        organization = 'ls',
+        certificates = selfsigned.generate([
+            {
+                name: 'commonName',
+                value: 'labshare.org'
+            }
+        ], {
+            days: 365
+        });
 
     let authServerUrl,
         authServer,
         authServerPort,
         app;
 
+    function createToken(sub, scope = '') {
+        return jws.sign({
+            sub,
+            jti: 123456,
+            azp: 123,
+            audience: [],
+            scope
+        }, certificates.private, {
+            algorithm: 'RS256',
+            expiresIn: '10m',
+            issuer: 'issuer',
+            keyid: '1'
+        });
+    }
+
     beforeEach(done => {
         app = express();
 
         app.get('/auth/me', (req, res) => {
-            let authToken = req.headers['auth-token'];
+            const authToken = req.headers['auth-token'];
 
             res.json(getProfile(authToken));
+        });
+
+        // Create a JSON Web Key from the PEM
+        const jwk = pem2jwk(certificates.private);
+
+        // Azure AD checks for the 'use' and 'kid' properties
+        jwk.kid = '1';
+        jwk.use = 'sig';
+
+        app.get(`/auth/${organization}/.well-known/jwks.json`, (req, res) => {
+            res.json({
+                keys: [
+                    jwk
+                ]
+            });
         });
 
         portfinder.getPort((err, unusedPort) => {
@@ -78,7 +120,7 @@ describe('Services-Auth', () => {
             servicesServer;
 
         beforeEach(done => {
-            let loggerMock = jasmine.createSpyObj('logger', ['error', 'info', 'warn']);
+            const loggerMock = jasmine.createSpyObj('logger', ['error', 'info', 'warn']);
 
             portfinder.getPort((err, unusedPort) => {
                 if (err) {
@@ -113,11 +155,79 @@ describe('Services-Auth', () => {
             servicesServer.close(done);
         });
 
-        describe('with default getUser function', () => {
+        describe('when authorizing with Resource Scopes', () => {
 
             beforeEach(() => {
                 services.config(servicesAuth({
-                    authUrl: authServerUrl
+                    authUrl: authServerUrl,
+                    organization: 'ls'
+                }));
+
+                servicesServer = services.start();
+
+                request = supertest(servicesServer);
+                clientSocket = clientio.connect(socketAPIUrl);
+            });
+
+            it('allows users with the appropriate scopes', done => {
+                const token = createToken(1, 'read:books');
+
+                request.get('/api-package-1-namespace/books')
+                    .set('auth-token', token)
+                    .expect('got books')
+                    .then(() => {
+                        done();
+                    })
+                    .catch(done.fail);
+            });
+
+            it('blocks users without the appropriate scopes', done => {
+                const token = createToken(1, 'read:books');
+
+                request.post('/api-package-1-namespace/books')
+                    .set('auth-token', token)
+                    .expect(401)
+                    .then(() => {
+                        done();
+                    })
+                    .catch(done.fail);
+            });
+
+            it('checks if the user is authorized with socket messages', done => {
+                const token = createToken(1, 'read:books');
+
+                clientSocket.emit('read.books', {token}, (error, result) => {
+                    if (error) {
+                        done.fail(error);
+                        return;
+                    }
+
+                    expect(result).toBe('got books');
+
+                    done();
+                });
+            });
+
+            it('blocks socket messages without the appropriate scope', done => {
+                const token = createToken(1);
+
+                clientSocket.emit('write.books', {token}, (error, message) => {
+                    expect(message).toBeUndefined();
+                    expect(error.message).toBe('Unauthorized');
+                    expect(error.data.code).toBe(401);
+
+                    done();
+                });
+            });
+
+        });
+
+        describe('with legacy access level check', () => {
+
+            beforeEach(() => {
+                services.config(servicesAuth({
+                    authUrl: authServerUrl,
+                    organization: 'ls'
                 }));
 
                 servicesServer = services.start();
@@ -127,8 +237,10 @@ describe('Services-Auth', () => {
             });
 
             it('allows users with the appropriate role', done => {
+                const token = createToken(2);
+
                 request.get('/api-package-1-namespace/staff/task')
-                    .set('auth-token', 'staff-token')
+                    .set('auth-token', token)
                     .expect('staff task complete')
                     .then(() => {
                         done();
@@ -137,8 +249,10 @@ describe('Services-Auth', () => {
             });
 
             it('blocks users without sufficient privileges', done => {
+                const token = createToken(1);
+
                 request.get('/api-package-1-namespace/admin/task')
-                    .set('auth-token', 'user-token')
+                    .set('auth-token', token)
                     .expect(403)
                     .then(() => {
                         done();
@@ -147,18 +261,24 @@ describe('Services-Auth', () => {
             });
 
             it('checks if the user is authorized with socket messages', done => {
-                clientSocket.emit('staff.task', {token: 'staff-token'}, (error, result) => {
+                const token = createToken(2);
+
+                clientSocket.emit('staff.task', {token}, (error, result) => {
                     if (error) {
                         done.fail(error);
                         return;
                     }
+
                     expect(result).toBe('staff task complete');
+
                     done();
                 });
             });
 
             it('fails to authorize user if they do not have the appropriate role', done => {
-                clientSocket.emit('admin.task', {token: 'user-token'}, (error, message) => {
+                const token = createToken(1);
+
+                clientSocket.emit('admin.task', {token}, (error, message) => {
                     expect(message).toBeUndefined();
                     expect(error.message).toBe('Forbidden');
                     expect(error.data.code).toBe(403);
@@ -167,19 +287,23 @@ describe('Services-Auth', () => {
             });
 
             it('allows complex interactions such as role-based channel notifications', done => {
-                let clientA = clientio.connect(socketAPIUrl),
+                const clientA = clientio.connect(socketAPIUrl),
                     clientB = clientio.connect(socketAPIUrl),
                     clientC = clientio.connect(socketAPIUrl),
                     clientD = clientio.connect(socketAPIUrl);
 
+                const userToken = createToken(1);
+                const staffToken = createToken(2);
+                const adminToken = createToken(3);
+
                 // Can't subscribe to notifications without the correct role
-                clientB.emit('subscribe:notifications', {token: 'user-token'}, error => {
+                clientB.emit('subscribe:notifications', {token: userToken}, error => {
                     expect(error.data.code).toBe(403);
 
                     clientB.disconnect();
                 });
 
-                clientD.emit('subscribe:notifications', {token: 'admin-token'}, (error, message) => {
+                clientD.emit('subscribe:notifications', {token: adminToken}, (error, message) => {
                     expect(message).toContain('Archived admin notification 1');
                 });
 
@@ -187,7 +311,7 @@ describe('Services-Auth', () => {
                     jasmine.fail('Admin user should not be in the staff channel!');
                 });
 
-                clientA.emit('subscribe:notifications', {token: 'staff-token'}, (error, message) => {
+                clientA.emit('subscribe:notifications', {token: staffToken}, (error, message) => {
                     expect(message).toContain('Archived notification 1');
                 });
 
@@ -201,7 +325,7 @@ describe('Services-Auth', () => {
                     done();
                 });
 
-                clientC.emit('subscribe:notifications', {token: 'staff-token'}, (error, message) => {
+                clientC.emit('subscribe:notifications', {token: staffToken}, (error, message) => {
                     expect(message).toContain('Archived notification 1');
 
                     // The resulting notification should be sent to everyone subscribed to the staff channel
@@ -209,65 +333,6 @@ describe('Services-Auth', () => {
                         expect(error).toBeNull();
                         expect(message).toContain('processing finished');
                     });
-                });
-            });
-
-        });
-
-        describe('with a custom getUser function', () => {
-
-            beforeEach(() => {
-                services.config(servicesAuth({
-                    getUser: ({}, callback) => {
-                        callback(null, {
-                            role: 'staff'
-                        });
-                    }
-                }));
-
-                servicesServer = services.start();
-
-                request = supertest(servicesServer);
-                clientSocket = clientio.connect(socketAPIUrl);
-            });
-
-            it('allows users with the appropriate role', done => {
-                request.get('/api-package-1-namespace/staff/task')
-                    .set('auth-token', 'staff-token')
-                    .expect('staff task complete')
-                    .then(() => {
-                        done();
-                    })
-                    .catch(done.fail);
-            });
-
-            it('blocks users without sufficient privileges', done => {
-                request.get('/api-package-1-namespace/admin/task')
-                    .set('auth-token', 'user-token')
-                    .expect(403)
-                    .then(() => {
-                        done();
-                    })
-                    .catch(done.fail);
-            });
-
-            it('checks if the user is authorized with socket messages', done => {
-                clientSocket.emit('staff.task', {token: 'staff-token'}, (error, result) => {
-                    if (error) {
-                        done.fail(error);
-                        return;
-                    }
-                    expect(result).toBe('staff task complete');
-                    done();
-                });
-            });
-
-            it('fails to authorize user if they do not have the appropriate role', done => {
-                clientSocket.emit('admin.task', {token: 'user-token'}, (error, message) => {
-                    expect(message).toBeUndefined();
-                    expect(error.message).toBe('Forbidden');
-                    expect(error.data.code).toBe(403);
-                    done();
                 });
             });
 

--- a/test/unit/lib/restrict-route_spec.js
+++ b/test/unit/lib/restrict-route_spec.js
@@ -134,31 +134,10 @@ describe('restrict', () => {
                 .catch(done.fail);
         });
 
-        it('does not authenticate if the route has a public accessLevel', done => {
+        it('does not check authorization if the route has a public accessLevel', done => {
             route.accessLevel = 'public';
 
             app.get('/test', restrict({route, getUser: authUserMock}), successMiddleware);
-
-            request
-                .get('/test')
-                .set('auth-token', authToken)
-                .expect(200)
-                .then(() => {
-                    expect(authUserMock).not.toHaveBeenCalled();
-                    done();
-                })
-                .catch(done.fail);
-        });
-
-        it('does not authenticate if the user is already authenticated', done => {
-            function auth(req, res, next) {
-                req.user = {};
-                next();
-            }
-
-            route.accessLevel = 'admin';
-
-            app.get('/test', auth, restrict({route, getUser: authUserMock}), successMiddleware);
 
             request
                 .get('/test')


### PR DESCRIPTION
 - Remove unused 'getUser' option
 - Make 'authURL' and 'organization' required options
 - Set up custom JWKS client for socket API requests