### PR TITLE
feat: rename "organization" configuration option to "tenant" AUTH-1217

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ npm i @labshare/services-auth --save
 ## Options
 
  * `authUrl` (`String`) - The base URL for a remote LabShare Auth service. Example: `https://a.labshare.org/_api`. Required.
- * `organization` (`String`) - The LabShare Auth organization ID the API service is registered to. Required if `secretProvider` is not specified.
+ * `tenant` (`String`) - The LabShare Auth Tenant ID the API service is registered to. Required if
+ `secretProvider` is not specified.
  * `audience` (`String`) - An optional API service identifier used for JWT `audience` validation. This is the identifier of an API service (OAuth Resource Server) registered to the LabShare Auth system.
  * `issuer` (`String`) - Optional value for validating the JWT issuer (the `iss` claim).
  * `secretProvider` (`Function`) - An optional, custom function for obtaining the signing certificate for RS256. The signature is `(req, header: {alg: string}, payload, cb: (error: Error, signingCert: string) => void): void`.
@@ -26,7 +27,8 @@ npm i @labshare/services-auth --save
 
 This example demonstrates scope-based authorization for an HTTP API module using `@labshare/services` to load the route definition.
 With the configuration below, only JWTs containing an audience of `https://my.api.identifier/resource` and a `read:users` scope
-would be allowed to access the API route. Additionally, the JWT would be validated using the JSON Web Key Set of the specified organization.
+would be allowed to access the API route. Additionally, the JWT would be validated using the JSON Web Key Set of the
+specified LabShare Auth Tenant.
 
 ```js
 // api/users.js
@@ -48,8 +50,8 @@ module.exports = {
 ```js
 // lib/index.js
 
-const {Services} = require('@labshare/services'),
-    servicesAuth = require('@labshare/services-auth');
+const {Services} = require('@labshare/services');
+const servicesAuth = require('@labshare/services-auth');
 
 const services = new Services(/* options */);
 
@@ -58,16 +60,18 @@ services.config(servicesAuth({
     authUrl: 'https://ls.auth.io/_api',
     audience: 'https://my.api.identifier/resource',
     issuer: 'LabShare Auth',
-    organization: 'my-org'
+    tenant: 'my-org'
 }));
 
 services.start();
 ```
 
 ## Development
-1. Install Node.js 6+
-2. Run `npm install` in the root directory of `services-auth`.
+
+1. Install Node.js >= 8.11.2
+2. `npm i`
 
 ## Tests
+
 `npm test`
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,7 +91,7 @@ function restrictAudience(audience) {
 /**
  * @description Enables Resource Scope authorization on LabShare Service API routes and sockets using RS256 for JWT validation.
  * @param {String} authUrl - The base URL for the LabShare Auth service.
- * @param {String} organization - A LabShare Auth organization. Optional if `secretProvider` is specified.
+ * @param {String} tenant - A LabShare Auth Tenant. Optional if `secretProvider` is specified.
  * @param {String} [audience] - A unique identifier for the API service registered as a Resource Server in LabShare Auth
  * @param {String} [issuer] - Validate JWT issuer claim against the expected value
  * @param {Function|null} secretProvider - Custom function for obtaining the RS256 signing certificate. Function signature: (req, header, payload, cb).
@@ -99,13 +99,13 @@ function restrictAudience(audience) {
  * to each socket and route definition.
  * @public
  */
-module.exports = function authorize({authUrl, organization, secretProvider = null, audience = null, issuer = null}) {
+module.exports = function authorize({authUrl, tenant, secretProvider = null, audience = null, issuer = null}) {
     if (!authUrl) {
         throw new Error('`authUrl` is required');
     }
 
-    if (!organization && !secretProvider) {
-        throw new Error('`organization` is required');
+    if (!tenant && !secretProvider) {
+        throw new Error('`tenant` is required');
     }
 
     const getUser = authUser({authUrl}),
@@ -113,7 +113,7 @@ module.exports = function authorize({authUrl, organization, secretProvider = nul
             cache: true,
             rateLimit: true,   // See: https://github.com/auth0/node-jwks-rsa#rate-limiting
             jwksRequestsPerMinute: 10,
-            jwksUri: `${authUrl}/auth/${organization}/.well-known/jwks.json`
+            jwksUri: `${authUrl}/auth/${tenant}/.well-known/jwks.json`
         },
         defaultSecretProvider = jwksClient.expressJwtSecret(jwksClientOptions);
 

--- a/test/unit/lib/index_spec.js
+++ b/test/unit/lib/index_spec.js
@@ -35,7 +35,7 @@ describe('Services-Auth', () => {
 
     const packagesPath = './test/fixtures/main-package',
         apiPackage1Prefix = '/socket-api-package-1-namespace',
-        organization = 'ls',
+        tenant = 'ls',
         defaultAudience = 'https://my.api.id/v2',
         certificates = selfsigned.generate([
             {
@@ -84,7 +84,7 @@ describe('Services-Auth', () => {
         jwk.kid = '1';
         jwk.use = 'sig';
 
-        app.get(`/auth/${organization}/.well-known/jwks.json`, (req, res) => {
+        app.get(`/auth/${tenant}/.well-known/jwks.json`, (req, res) => {
             res.json({
                 keys: [
                     jwk
@@ -160,7 +160,7 @@ describe('Services-Auth', () => {
             beforeEach(() => {
                 services.config(servicesAuth({
                     authUrl: authServerUrl,
-                    organization,
+                    tenant,
                     audience: defaultAudience
                 }));
 
@@ -248,7 +248,7 @@ describe('Services-Auth', () => {
             beforeEach(() => {
                 services.config(servicesAuth({
                     authUrl: authServerUrl,
-                    organization,
+                    tenant,
                     audience: defaultAudience
                 }));
 


### PR DESCRIPTION
BREAKING CHANGE: The "organization" configuration option is now "tenant".