### PR TITLE
feat(authentication-decorator): support "credentialsRequired" option

### DIFF
--- a/src/decorators/authenticate.decorator.ts
+++ b/src/decorators/authenticate.decorator.ts
@@ -19,6 +19,7 @@ import {
  */
 export interface AuthenticationMetadata {
   scope?: string[];
+  credentialsRequired?: boolean;
 }
 
 class AuthenticateClassDecoratorFactory extends ClassDecoratorFactory<


### PR DESCRIPTION
Expose the "credentialsRequired" option from the https://www.npmjs.com/package/express-jwt library as an optional property for the
@authenticate() decorator. When set to false, the request sequence will not block anonymous requests.

Example:
```
@authenticate({
  scope: ['some.scope'],
  credentialsRequired: false
})
```