### PR TITLE
feat(config): support setting custom "requestProperty"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,7 @@ function restrictAudience(audience) {
  * @param {String} [audience] - A unique identifier for the API service registered as a Resource Server in LabShare Auth
  * @param {String} [issuer] - Validate JWT issuer claim against the expected value
  * @param {Function|null} secretProvider - Custom function for obtaining the RS256 signing certificate. Function signature: (req, header, payload, cb).
+ * @param {String} [requestProperty] - Customize which attribute the decoded token payload is set to. Default: "user"
  * @returns Express.js middleware function
  * @public
  */
@@ -84,7 +85,8 @@ function expressRs256({
                           tenant = null,
                           secretProvider = null,
                           audience = null,
-                          issuer = null
+                          issuer = null,
+                          requestProperty = 'user'
                       }) {
     if (!authUrl && !secretProvider) {
         throw new Error('`authUrl` is required');
@@ -106,7 +108,8 @@ function expressRs256({
         secret,
         audience,   // Optionally validate the audience and the issuer as well
         issuer,
-        algorithms: defaultAlgorithms
+        algorithms: defaultAlgorithms,
+        requestProperty
     });
 }
 


### PR DESCRIPTION
Forward "requestProperty" option to express-jwt to customize the request object attribute to set the decoded JWT payload to.